### PR TITLE
Added weighted shuffle capability to Order.shuffle

### DIFF
--- a/library.js
+++ b/library.js
@@ -1701,12 +1701,23 @@ const Order = (function () {
         // 0.0 pure order
         // 1.0 pure randomness (default)
 
-        for (let i = array.length - 1; i > 0; i--) {
-            let r = Math.floor(Math.random() * (i + 1));
-            let j = Math.floor(r * factor + i * (1 - factor));
-            [array[i], array[j]] = [array[j], array[i]];
-            // Logger.log((i+1) + " <-> " + (j+1) + "   " + array)
+        let length = array.length
+
+        // generate an array of random unique numbers from 0 to N
+        let indexArray = Array.from(Array(length).keys()).sort(_ => Math.random() - .5)
+
+        // Balanced Fisher-Yates with localised randomness factor
+        for (let i = 0; i < (length * factor); i++) {
+            let x = indexArray[i];
+            let r = Math.floor(Math.random() * (x + 1));
+            let y = Math.floor(r * factor + x * (1 - factor));
+            [array[x], array[y]] = [array[y], array[x]];
         }
+    }
+
+
+
+}
     }
 
     function reverse(array) {

--- a/library.js
+++ b/library.js
@@ -1695,10 +1695,17 @@ const Selector = (function () {
 })();
 
 const Order = (function () {
-    function shuffle(array) {
+    function shuffle(array, factor = 1.0 ) {
+
+        // Weighted shuffle
+        // 0.0 pure order
+        // 1.0 pure randomness (default)
+
         for (let i = array.length - 1; i > 0; i--) {
-            let j = Math.floor(Math.random() * (i + 1));
-            [array[i], array[j]] = [array[j], array[i]];
+          let r = Math.floor(Math.random() * (i + 1 ));
+          let j = Math.floor(r * factor + i * (1 - factor));
+          [array[i], array[j]] = [array[j], array[i]];
+          // Logger.log((i+1) + " <-> " + (j+1) + "   " + array)
         }
     }
 

--- a/library.js
+++ b/library.js
@@ -1702,10 +1702,10 @@ const Order = (function () {
         // 1.0 pure randomness (default)
 
         for (let i = array.length - 1; i > 0; i--) {
-          let r = Math.floor(Math.random() * (i + 1 ));
-          let j = Math.floor(r * factor + i * (1 - factor));
-          [array[i], array[j]] = [array[j], array[i]];
-          // Logger.log((i+1) + " <-> " + (j+1) + "   " + array)
+            let r = Math.floor(Math.random() * (i + 1 ));
+            let j = Math.floor(r * factor + i * (1 - factor));
+            [array[i], array[j]] = [array[j], array[i]];
+            // Logger.log((i+1) + " <-> " + (j+1) + "   " + array)
         }
     }
 

--- a/library.js
+++ b/library.js
@@ -1702,7 +1702,7 @@ const Order = (function () {
         // 1.0 pure randomness (default)
 
         for (let i = array.length - 1; i > 0; i--) {
-            let r = Math.floor(Math.random() * (i + 1 ));
+            let r = Math.floor(Math.random() * (i + 1));
             let j = Math.floor(r * factor + i * (1 - factor));
             [array[i], array[j]] = [array[j], array[i]];
             // Logger.log((i+1) + " <-> " + (j+1) + "   " + array)


### PR DESCRIPTION
Existing functionality and behaviour is preserved. But a second optional factor parameter, between 0.0 and 1.0 controls the level of randomness applied to the array. A value of 0.0 is pure order. A value of 1.0 (default) is pure randomness with the same result as before. This can be useful when only a small amount of randomness needs to be added to the track order. I actually use it in some of my programs with a factor of 0.05.